### PR TITLE
Force to kill children when killing a parent.

### DIFF
--- a/pytestsalt/utils.py
+++ b/pytestsalt/utils.py
@@ -182,6 +182,8 @@ def terminate_process(pid=None, process=None, children=None, kill_children=False
     '''
     children = children or []
     process_list = []
+    # Always kill children if kill the parent process.
+    kill_children = True if slow_stop is False else kill_children
 
     if pid and not process:
         try:


### PR DESCRIPTION
If we don't children will still alive.

I've reproduced it by running Salt `integration.shell.test_master.MasterTest` and checking `ps aux | grep python` after it's done.

I'll also add a case to the salt test that checks this issue.