### PR TITLE
Use copyright instead of unicode symbol

### DIFF
--- a/pytestsalt/salt/engines/pytest_engine.py
+++ b/pytestsalt/salt/engines/pytest_engine.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 '''
     :codeauthor: :email:`Pedro Algarvio (pedro@algarvio.me)`
-    :copyright: © 2015 by the SaltStack Team, see AUTHORS for more details.
+    :copyright: Copyright 2015 by the SaltStack Team, see AUTHORS for more details.
     :license: Apache 2.0, see LICENSE for more details.
 
 


### PR DESCRIPTION
Using the unicode symbol will make it so that tests cannot run on systems that
have locale set to a non unicode locale