### PR TITLE
Use copyright instead of unicode symbol

### DIFF
--- a/pytestsalt/__init__.py
+++ b/pytestsalt/__init__.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 '''
     :codeauthor: :email:`Pedro Algarvio (pedro@algarvio.me)`
-    :copyright: © 2015 by the SaltStack Team, see AUTHORS for more details.
+    :copyright: Copyright 2015 by the SaltStack Team, see AUTHORS for more details.
     :license: Apache 2.0, see LICENSE for more details.
 
 

--- a/pytestsalt/fixtures/__init__.py
+++ b/pytestsalt/fixtures/__init__.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 '''
     :codeauthor: :email:`Pedro Algarvio (pedro@algarvio.me)`
-    :copyright: © 2015 by the SaltStack Team, see AUTHORS for more details.
+    :copyright: Copyright 2015 by the SaltStack Team, see AUTHORS for more details.
     :license: Apache 2.0, see LICENSE for more details.
 
 

--- a/pytestsalt/fixtures/config.py
+++ b/pytestsalt/fixtures/config.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 '''
     :codeauthor: :email:`Pedro Algarvio (pedro@algarvio.me)`
-    :copyright: © 2015 by the SaltStack Team, see AUTHORS for more details.
+    :copyright: Copyright 2015 by the SaltStack Team, see AUTHORS for more details.
     :license: Apache 2.0, see LICENSE for more details.
 
 

--- a/pytestsalt/fixtures/daemons.py
+++ b/pytestsalt/fixtures/daemons.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 '''
     :codeauthor: :email:`Pedro Algarvio (pedro@algarvio.me)`
-    :copyright: © 2015 by the SaltStack Team, see AUTHORS for more details.
+    :copyright: Copyright 2015 by the SaltStack Team, see AUTHORS for more details.
     :license: Apache 2.0, see LICENSE for more details.
 
 

--- a/pytestsalt/fixtures/dirs.py
+++ b/pytestsalt/fixtures/dirs.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 '''
     :codeauthor: :email:`Pedro Algarvio (pedro@algarvio.me)`
-    :copyright: © 2015 by the SaltStack Team, see AUTHORS for more details.
+    :copyright: Copyright 2015 by the SaltStack Team, see AUTHORS for more details.
     :license: Apache 2.0, see LICENSE for more details.
 
 

--- a/pytestsalt/fixtures/log.py
+++ b/pytestsalt/fixtures/log.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 '''
     :codeauthor: :email:`Pedro Algarvio (pedro@algarvio.me)`
-    :copyright: © 2016 by the SaltStack Team, see AUTHORS for more details.
+    :copyright: Copyright 2016 by the SaltStack Team, see AUTHORS for more details.
     :license: Apache 2.0, see LICENSE for more details.
 
 

--- a/pytestsalt/fixtures/ports.py
+++ b/pytestsalt/fixtures/ports.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 '''
     :codeauthor: :email:`Pedro Algarvio (pedro@algarvio.me)`
-    :copyright: © 2015 by the SaltStack Team, see AUTHORS for more details.
+    :copyright: Copyright 2015 by the SaltStack Team, see AUTHORS for more details.
     :license: Apache 2.0, see LICENSE for more details.
 
 

--- a/pytestsalt/parser.py
+++ b/pytestsalt/parser.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 '''
     :codeauthor: :email:`Pedro Algarvio (pedro@algarvio.me)`
-    :copyright: © 2015 by the SaltStack Team, see AUTHORS for more details.
+    :copyright: Copyright 2015 by the SaltStack Team, see AUTHORS for more details.
     :license: Apache 2.0, see LICENSE for more details.
 
 

--- a/pytestsalt/salt/engines/pytest_engine.py
+++ b/pytestsalt/salt/engines/pytest_engine.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 '''
     :codeauthor: :email:`Pedro Algarvio (pedro@algarvio.me)`
-    :copyright: © 2015 by the SaltStack Team, see AUTHORS for more details.
+    :copyright: Copyright 2015 by the SaltStack Team, see AUTHORS for more details.
     :license: Apache 2.0, see LICENSE for more details.
 
 

--- a/pytestsalt/salt/loader.py
+++ b/pytestsalt/salt/loader.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 '''
     :codeauthor: :email:`Pedro Algarvio (pedro@algarvio.me)`
-    :copyright: © 2016 by the SaltStack Team, see AUTHORS for more details.
+    :copyright: Copyright 2016 by the SaltStack Team, see AUTHORS for more details.
     :license: Apache 2.0, see LICENSE for more details.
 
 

--- a/pytestsalt/salt/log_handlers/pytest_log_handler.py
+++ b/pytestsalt/salt/log_handlers/pytest_log_handler.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 '''
     :codeauthor: :email:`Pedro Algarvio (pedro@algarvio.me)`
-    :copyright: © 2016 by the SaltStack Team, see AUTHORS for more details.
+    :copyright: Copyright 2016 by the SaltStack Team, see AUTHORS for more details.
     :license: Apache 2.0, see LICENSE for more details.
 
 

--- a/pytestsalt/utils.py
+++ b/pytestsalt/utils.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 '''
     :codeauthor: :email:`Pedro Algarvio (pedro@algarvio.me)`
-    :copyright: © 2015 by the SaltStack Team, see AUTHORS for more details.
+    :copyright: Copyright 2015 by the SaltStack Team, see AUTHORS for more details.
     :license: Apache 2.0, see LICENSE for more details.
 
 

--- a/pytestsalt/version.py
+++ b/pytestsalt/version.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 '''
     :codeauthor: :email:`Pedro Algarvio (pedro@algarvio.me)`
-    :copyright: © 2015 by the SaltStack Team, see AUTHORS for more details.
+    :copyright: Copyright 2015 by the SaltStack Team, see AUTHORS for more details.
     :license: Apache 2.0, see LICENSE for more details.
 
 

--- a/tests/test_salt_call.py
+++ b/tests/test_salt_call.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 '''
     :codeauthor: :email:`Pedro Algarvio (pedro@algarvio.me)`
-    :copyright: © 2015 by the SaltStack Team, see AUTHORS for more details.
+    :copyright: Copyright 2015 by the SaltStack Team, see AUTHORS for more details.
     :license: Apache 2.0, see LICENSE for more details.
 
 

--- a/tests/test_salt_master.py
+++ b/tests/test_salt_master.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 '''
     :codeauthor: :email:`Pedro Algarvio (pedro@algarvio.me)`
-    :copyright: © 2015 by the SaltStack Team, see AUTHORS for more details.
+    :copyright: Copyright 2015 by the SaltStack Team, see AUTHORS for more details.
     :license: Apache 2.0, see LICENSE for more details.
 
 

--- a/tests/test_salt_minion.py
+++ b/tests/test_salt_minion.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 '''
     :codeauthor: :email:`Pedro Algarvio (pedro@algarvio.me)`
-    :copyright: © 2015 by the SaltStack Team, see AUTHORS for more details.
+    :copyright: Copyright 2015 by the SaltStack Team, see AUTHORS for more details.
     :license: Apache 2.0, see LICENSE for more details.
 
 


### PR DESCRIPTION
Using the unicode symbol will make it so that tests cannot run on systems that
have locale set to a non unicode locale