### PR TITLE
Additional fixes for 09955b4

### DIFF
--- a/pytestsalt/fixtures/config.py
+++ b/pytestsalt/fixtures/config.py
@@ -797,13 +797,13 @@ def apply_master_config(root_dir,
         salt_verify.verify_env(
             verify_env_entries,
             running_username,
-            pki_dir=options['pki_dir']
+            sensitive_dirs=[options['pki_dir']]
         )
     except TypeError:
         salt_verify.verify_env(
             verify_env_entries,
             running_username,
-            sensitive_dirs=[options['pki_dir']]
+            pki_dir=options['pki_dir']
         )
     return options
 
@@ -1075,16 +1075,18 @@ def apply_minion_config(root_dir,
         options['sock_dir'],
     ]
     try:
-        salt_verify.verify_env(
-            verify_env_entries,
-            running_username,
-            pki_dir=options['pki_dir']
-        )
-    except TypeError:
+        # Salt > v2017.7.x
         salt_verify.verify_env(
             verify_env_entries,
             running_username,
             sensitive_dirs=[options['pki_dir']]
+        )
+    except TypeError:
+        # Salt <= v2017.7.x
+        salt_verify.verify_env(
+            verify_env_entries,
+            running_username,
+            pki_dir=options['pki_dir']
         )
     return options
 


### PR DESCRIPTION
Try the recent signature first to avoid getting the deprecation warning.