### PR TITLE
create sshd privileged directory if it doesn't exist.

### DIFF
--- a/pytestsalt/fixtures/daemons.py
+++ b/pytestsalt/fixtures/daemons.py
@@ -1326,6 +1326,7 @@ def sshd_server(request,
                 sshd_server_log_prefix,
                 sshd_port,
                 sshd_config_dir,
+                sshd_priv_dir,
                 log_server):  # pylint: disable=unused-argument
     '''
     Returns a running sshd server
@@ -1420,6 +1421,7 @@ def session_sshd_server(request,
                         session_sshd_server_log_prefix,
                         session_sshd_port,
                         session_sshd_config_dir,
+                        session_sshd_priv_dir,
                         log_server):  # pylint: disable=unused-argument
     '''
     Returns a running sshd server

--- a/pytestsalt/fixtures/dirs.py
+++ b/pytestsalt/fixtures/dirs.py
@@ -15,6 +15,8 @@
 # Import Python libs
 from __future__ import absolute_import
 import logging
+import os
+import stat
 
 # Import 3rd-party libs
 import pytest
@@ -589,6 +591,32 @@ def session_sshd_config_dir(tempdir):
     config_dir = tempdir.join('session-sshd')
     config_dir.ensure(dir=True)
     return config_dir
+
+
+@pytest.fixture
+def sshd_priv_dir():
+    '''
+    Create the privdir for starting sshd on systems that do not have an sshd
+    daemon already running
+    '''
+    if not os.path.isdir('/var/run/sshd')
+        os.mkdir('/var/run/sshd/')
+        os.chmod('/var/run/sshd/', stat.S_IRWXU | stat.S_IRGRP | stat.S_IXGRP | stat.S_IROTH | stat.S_IXOTH)
+        yield
+        os.rmdir('/var/run/sshd')
+
+
+@pytest.fixture(scope='session')
+def session_sshd_priv_dir():
+    '''
+    Create the privdir for starting sshd on systems that do not have an sshd
+    daemon already running
+    '''
+    if not os.path.isdir('/var/run/sshd')
+        os.mkdir('/var/run/sshd/')
+        os.chmod('/var/run/sshd/', stat.S_IRWXU | stat.S_IRGRP | stat.S_IXGRP | stat.S_IROTH | stat.S_IXOTH)
+        yield
+        os.rmdir('/var/run/sshd')
 
 
 @pytest.fixture


### PR DESCRIPTION
On systems that do not have sshd already running, like dumb docker
containers, /var/run/sshd needs to exist in order to start the sshd
server.  Create it if it doesn't exist.