### PR TITLE
Remove deprecated kwarg from call to add_accept_handler()

### DIFF
--- a/pytestsalt/salt/engines/pytest_engine.py
+++ b/pytestsalt/salt/engines/pytest_engine.py
@@ -71,7 +71,6 @@ class PyTestEngine(object):
         netutil.add_accept_handler(
             self.sock,
             self.handle_connection,
-            io_loop=self.io_loop,
         )
 
     def handle_connection(self, connection, address):


### PR DESCRIPTION
The `io_loop` argument to `netutil.add_accept_handler()` has been [deprecated since tornado 4.1](http://www.tornadoweb.org/en/stable/netutil.html#tornado.netutil.add_accept_handler), and it was removed in 5.0. In 4.x, if the caller passes no `io_loop`, tornado will use the current one, which is what we were explicitly doing by passing `io_loop`. (In other words, this change will not break our use of `add_accept_handler()`).

cc: @s0undt3ch 