### PR TITLE
fix sshd daemons/configs

### DIFF
--- a/pytestsalt/fixtures/config.py
+++ b/pytestsalt/fixtures/config.py
@@ -1795,9 +1795,8 @@ def _write_sshd_config(sshd_config_dir, sshd_config_lines, ssh_client_key):
     '''
     This fixture will write the necessary configuration to run an SSHD server to be used in tests
     '''
-    import salt.utils
     import pytestsalt.utils.compat as compat
-    sshd = salt.utils.which('sshd')
+    sshd = compat.which('sshd')
 
     if not sshd:
         pytest.skip('"sshd" not found.')
@@ -1842,9 +1841,9 @@ def _generate_ssh_key(key_path, key_type='ecdsa', key_size=521):
     '''
     Generate an SSH key
     '''
-    import salt.utils
+    import pytestsalt.utils.compat as compat
     log.debug('Generating ssh key(type: %s; size: %d; path: %s;)', key_type, key_size, key_path)
-    keygen = salt.utils.which('ssh-keygen')
+    keygen = compat.which('ssh-keygen')
     if not keygen:
         pytest.skip('"ssh-keygen" not found')
 

--- a/pytestsalt/fixtures/daemons.py
+++ b/pytestsalt/fixtures/daemons.py
@@ -1654,8 +1654,8 @@ class SSHD(SaltDaemonScriptBase):
         '''
         Returns the path to the script to run
         '''
-        import salt.utils
-        sshd = salt.utils.which(self.cli_script_name)
+        import pytestsalt.utils.compat as compat
+        sshd = compat.which(self.cli_script_name)
         if not sshd:
             pytest.skip('"sshd" not found')
         return sshd

--- a/pytestsalt/utils/compat.py
+++ b/pytestsalt/utils/compat.py
@@ -15,3 +15,12 @@ except AttributeError:
     # Salt <= 2017.1.1
     # pylint: disable=invalid-name
     fopen = salt.utils.fopen
+
+try:
+    # Salt >= 2018.3.0
+    # pylint: disable=invalid-name
+    from salt.utils.path import which
+except ImportError:
+    # Salt < 2018.3.0
+    # pylint: disable=invalid-name
+    from salt.utils import which


### PR DESCRIPTION
Add which to pytestsalt.utils.compat since it is moved in 2018.3, and
removed in neon