### PR TITLE
Use salt's vendored tornado first

### DIFF
--- a/pytestsalt/utils/log_server_tornado.py
+++ b/pytestsalt/utils/log_server_tornado.py
@@ -13,10 +13,17 @@ import threading
 
 # Import 3rd-party libs
 import msgpack
-from tornado import gen
-from tornado.ioloop import IOLoop
-from tornado.tcpserver import TCPServer
-from tornado.iostream import StreamClosedError
+
+try:
+    from salt.ext.tornado import gen
+    from salt.ext.tornado.ioloop import IOLoop
+    from salt.ext.tornado.tcpserver import TCPServer
+    from salt.ext.tornado.iostream import StreamClosedError
+except ImportError:
+    from tornado import gen
+    from tornado.ioloop import IOLoop
+    from tornado.tcpserver import TCPServer
+    from tornado.iostream import StreamClosedError
 
 log = logging.getLogger(__name__)
 


### PR DESCRIPTION
Use salt's vendored tornado first. On the head of master on salt we no longer include tornado as a requirement in our test suite. Without this change will see this error:

```
  File "/salt/.nox/pytest-parametrized-3-coverage-false-crypto-none-transport-zeromq/lib/python3.5/site-packages/pytestsalt/fixtures/log.py", line 22, in <module>
    from pytestsalt.utils.log_server_tornado import log_server_tornado as salt_log_server
  File "/salt/.nox/pytest-parametrized-3-coverage-false-crypto-none-transport-zeromq/lib/python3.5/site-packages/_pytest/assertion/rewrite.py", line 304, in load_module
    exec(co, mod.__dict__)
  File "/salt/.nox/pytest-parametrized-3-coverage-false-crypto-none-transport-zeromq/lib/python3.5/site-packages/pytestsalt/utils/log_server_tornado.py", line
16, in <module>
    from tornado import gen
ImportError: No module named 'tornado'
```